### PR TITLE
Refactor film overview UI into modular components

### DIFF
--- a/tv2/src/components/AppHeader.tsx
+++ b/tv2/src/components/AppHeader.tsx
@@ -1,0 +1,15 @@
+import type { FC, ReactNode } from 'react'
+
+type AppHeaderProps = {
+  title: ReactNode
+  subtitle: ReactNode
+}
+
+const AppHeader: FC<AppHeaderProps> = ({ title, subtitle }) => (
+  <header className="app__header">
+    <h1 className="app__title">{title}</h1>
+    <p className="app__subtitle">{subtitle}</p>
+  </header>
+)
+
+export default AppHeader

--- a/tv2/src/components/DetailsPanel.tsx
+++ b/tv2/src/components/DetailsPanel.tsx
@@ -1,0 +1,71 @@
+import type { FC } from 'react'
+import type { MovieDetails } from '../api/movies'
+import { formatDuration } from '../utils/formatDuration'
+import StatusMessage from './StatusMessage'
+
+type DetailsPanelProps = {
+  movie: MovieDetails | null
+  isLoading: boolean
+  error?: string | null
+  playbackHref?: string | null
+}
+
+const DetailsPanel: FC<DetailsPanelProps> = ({ movie, isLoading, error, playbackHref }) => {
+  const durationLabel = movie?.durationSeconds
+    ? formatDuration(movie.durationSeconds)
+    : movie?.rawDuration ?? null
+
+  return (
+    <section className="details" aria-live="polite">
+      {isLoading && <div className="details__skeleton" aria-hidden="true" />}
+
+      {movie && (
+        <>
+          {movie.imageUrl && (
+            <img
+              src={movie.imageUrl}
+              alt={`Filmplakat for ${movie.title}`}
+              className="details__poster"
+            />
+          )}
+
+          <div className="details__body">
+            <h2 className="details__title">{movie.title}</h2>
+
+            {error && (
+              <StatusMessage tone="error" role="alert">
+                {error}
+              </StatusMessage>
+            )}
+
+            <p className="details__description">
+              {movie.description ?? 'Ingen beskrivelse tilgjengelig for denne filmen.'}
+            </p>
+
+            <div className="details__meta">
+              {durationLabel && <span>Varighet: {durationLabel}</span>}
+              <span>API-sti: {movie.url}</span>
+            </div>
+
+            {playbackHref && (
+              <div className="details__actions">
+                <a className="details__link" href={playbackHref} rel="noreferrer">
+                  Åpne i demoen
+                </a>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {!isLoading && !movie && (
+        <div className="details__empty">
+          <h2>Velg en film for å se detaljer</h2>
+          <p>Vi henter informasjonen direkte fra API-et og viser den her.</p>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default DetailsPanel

--- a/tv2/src/components/MovieCard.tsx
+++ b/tv2/src/components/MovieCard.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react'
+import type { MovieSummary } from '../api/movies'
+
+type MovieCardProps = {
+  movie: MovieSummary
+  isActive: boolean
+  onSelect: (movie: MovieSummary) => void
+}
+
+const MovieCard: FC<MovieCardProps> = ({ movie, isActive, onSelect }) => {
+  return (
+    <button
+      type="button"
+      className={`movie-card${isActive ? ' movie-card--active' : ''}`}
+      onClick={() => onSelect(movie)}
+      aria-pressed={isActive}
+    >
+      {movie.imageUrl ? (
+        <img
+          src={movie.imageUrl}
+          alt={`Filmplakat for ${movie.title}`}
+          className="movie-card__poster"
+          loading="lazy"
+        />
+      ) : (
+        <div className="movie-card__poster movie-card__poster--empty">Ingen plakat</div>
+      )}
+      <h3 className="movie-card__title">{movie.title}</h3>
+    </button>
+  )
+}
+
+export default MovieCard

--- a/tv2/src/components/MovieCardSkeleton.tsx
+++ b/tv2/src/components/MovieCardSkeleton.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+
+const MovieCardSkeleton: FC = () => (
+  <div className="movie-card movie-card--loading" aria-hidden="true">
+    <div className="movie-card__poster movie-card__poster--skeleton" />
+    <div className="movie-card__title movie-card__title--skeleton" />
+  </div>
+)
+
+export default MovieCardSkeleton

--- a/tv2/src/components/MovieGrid.tsx
+++ b/tv2/src/components/MovieGrid.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react'
+import type { MovieSummary } from '../api/movies'
+import MovieCard from './MovieCard'
+import MovieCardSkeleton from './MovieCardSkeleton'
+
+type MovieGridProps = {
+  movies: MovieSummary[]
+  isLoading: boolean
+  activeMovie: MovieSummary | null
+  onSelectMovie: (movie: MovieSummary) => void
+}
+
+const MovieGrid: FC<MovieGridProps> = ({ movies, isLoading, activeMovie, onSelectMovie }) => {
+  return (
+    <section className="movie-grid" aria-live="polite">
+      {isLoading
+        ? Array.from({ length: 6 }).map((_, index) => <MovieCardSkeleton key={`skeleton-${index}`} />)
+        : movies.map((movie) => (
+            <MovieCard
+              key={movie.id}
+              movie={movie}
+              isActive={activeMovie?.url === movie.url}
+              onSelect={onSelectMovie}
+            />
+          ))}
+    </section>
+  )
+}
+
+export default MovieGrid

--- a/tv2/src/components/StatusMessage.tsx
+++ b/tv2/src/components/StatusMessage.tsx
@@ -1,0 +1,21 @@
+import type { FC, ReactNode } from 'react'
+
+type StatusTone = 'default' | 'error'
+
+type StatusMessageProps = {
+  tone?: StatusTone
+  children: ReactNode
+  role?: 'status' | 'alert'
+}
+
+const StatusMessage: FC<StatusMessageProps> = ({ tone = 'default', children, role }) => {
+  const className = `app__status${tone === 'error' ? ' app__status--error' : ''}`
+
+  return (
+    <div className={className} role={role}>
+      {children}
+    </div>
+  )
+}
+
+export default StatusMessage

--- a/tv2/src/utils/errors.ts
+++ b/tv2/src/utils/errors.ts
@@ -1,0 +1,9 @@
+export function isAbortError(error: unknown): boolean {
+  if (!error) {
+    return false
+  }
+
+  return error instanceof DOMException
+    ? error.name === 'AbortError'
+    : typeof error === 'object' && 'name' in error && (error as { name?: string }).name === 'AbortError'
+}

--- a/tv2/src/utils/formatDuration.ts
+++ b/tv2/src/utils/formatDuration.ts
@@ -1,0 +1,22 @@
+export function formatDuration(durationSeconds: number): string {
+  const totalSeconds = Math.max(0, Math.round(durationSeconds))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  const parts: string[] = []
+
+  if (hours > 0) {
+    parts.push(`${hours} t`)
+  }
+
+  if (minutes > 0) {
+    parts.push(`${minutes} min`)
+  }
+
+  if (parts.length === 0) {
+    parts.push(`${seconds} s`)
+  }
+
+  return parts.join(' ')
+}


### PR DESCRIPTION
## Summary
- Extract reusable UI components for the header, movie grid, and details panel to simplify the main app
- Move duration formatting and abort detection helpers into utility modules for reuse
- Replace the external TV 2 link with an internal demo link so navigation stays inside the clone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de99d99288832fa5fdd7b4b4a8022a