### PR TITLE
feat: redesign movie browser with TV 2 Play inspired UI

### DIFF
--- a/tv2/src/App.css
+++ b/tv2/src/App.css
@@ -10,6 +10,47 @@
   gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
+.app__content {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 2fr);
+  align-items: flex-start;
+}
+
+.app__title-accent {
+  font-weight: 600;
+  color: #5cb6ff;
+}
+
+.app__grid-panel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border-radius: 1.25rem;
+  background: linear-gradient(150deg, rgba(8, 12, 24, 0.88), rgba(5, 7, 15, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 22px 45px rgba(5, 8, 16, 0.55);
+}
+
+.app__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.app__section-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  font-weight: 600;
+}
+
+.app__section-description {
+  margin: 0;
+  color: rgba(246, 247, 251, 0.7);
+  font-size: 0.95rem;
+}
+
 .app__header {
   display: flex;
   flex-direction: column;
@@ -249,6 +290,12 @@ button.movie-card:active {
   }
 }
 
+@media (max-width: 1024px) {
+  .app__content {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
   .movie-grid {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -260,5 +307,11 @@ button.movie-card:active {
 
   .details__poster {
     width: 100%;
+  }
+}
+
+@media (min-width: 769px) {
+  .app__content {
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 2.3fr);
   }
 }

--- a/tv2/src/App.tsx
+++ b/tv2/src/App.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
-import { fetchMovies } from './api/movies'
-import type { MovieSummary } from './api/movies'
+import { fetchMovieDetails, fetchMovies } from './api/movies'
+import type { MovieDetails, MovieSummary } from './api/movies'
 import { isAbortError } from './utils/errors'
+import AppHeader from './components/AppHeader'
+import MovieGrid from './components/MovieGrid'
+import DetailsPanel from './components/DetailsPanel'
+import StatusMessage from './components/StatusMessage'
 
 const FALLBACK_MOVIES: MovieSummary[] = [
   {
@@ -30,23 +34,37 @@ const FALLBACK_MOVIES: MovieSummary[] = [
 
 function App() {
   const [movies, setMovies] = useState<MovieSummary[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [activeMovie, setActiveMovie] = useState<MovieSummary | null>(null)
+  const [isLoadingMovies, setIsLoadingMovies] = useState(true)
+  const [moviesError, setMoviesError] = useState<string | null>(null)
+  const [activeDetails, setActiveDetails] = useState<MovieDetails | null>(null)
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
+  const [detailsError, setDetailsError] = useState<string | null>(null)
 
   useEffect(() => {
     const controller = new AbortController()
-    setIsLoading(true)
-    setError(null)
+    setIsLoadingMovies(true)
+    setMoviesError(null)
 
     fetchMovies(controller.signal)
       .then((fetched) => {
         if (fetched.length === 0) {
           setMovies(FALLBACK_MOVIES)
-          setError('Fant ingen filmer i feeden. Viser eksempeldata i stedet.')
+          setMoviesError('Fant ingen filmer i feeden. Viser eksempeldata i stedet.')
+          setActiveMovie(FALLBACK_MOVIES[0] ?? null)
           return
         }
 
         setMovies(fetched)
+        setActiveMovie((current) => {
+          if (!current) {
+            return fetched[0] ?? null
+          }
+
+          return (
+            fetched.find((movie) => movie.id === current.id || movie.url === current.url) ?? fetched[0] ?? null
+          )
+        })
       })
       .catch((error) => {
         if (isAbortError(error)) {
@@ -55,10 +73,11 @@ function App() {
 
         console.error('Kunne ikke hente filmer fra API-et', error)
         setMovies(FALLBACK_MOVIES)
-        setError('Kunne ikke hente filmer fra API-et. Viser eksempeldata i stedet.')
+        setMoviesError('Kunne ikke hente filmer fra API-et. Viser eksempeldata i stedet.')
+        setActiveMovie(FALLBACK_MOVIES[0] ?? null)
       })
       .finally(() => {
-        setIsLoading(false)
+        setIsLoadingMovies(false)
       })
 
     return () => {
@@ -66,24 +85,101 @@ function App() {
     }
   }, [])
 
+  useEffect(() => {
+    if (!activeMovie) {
+      setActiveDetails(null)
+      setDetailsError(null)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoadingDetails(true)
+    setDetailsError(null)
+    setActiveDetails(null)
+
+    fetchMovieDetails(activeMovie.url, controller.signal, activeMovie)
+      .then((details) => {
+        setActiveDetails(details)
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return
+        }
+
+        console.error('Kunne ikke hente detaljer for filmen', error)
+        setDetailsError('Kunne ikke hente detaljer for denne filmen akkurat nå. Viser begrenset info i stedet.')
+        setActiveDetails({
+          ...activeMovie,
+          description: 'Vi kunne ikke hente mer informasjon om denne filmen akkurat nå.',
+        })
+      })
+      .finally(() => {
+        setIsLoadingDetails(false)
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [activeMovie])
+
+  const playbackHref = useMemo(() => buildPlaybackHref(activeDetails?.url), [activeDetails?.url])
+
   return (
     <div className="app">
-      <h1 className="app__title">Filmer</h1>
+      <AppHeader
+        title={
+          <>
+            TV 2 Play <span className="app__title-accent">demo</span>
+          </>
+        }
+        subtitle="Utforsk filmlisten som hentes direkte fra TV 2 Play sitt API og se detaljer i sanntid."
+      />
 
-      {isLoading ? (
-        <p>Laster filmer …</p>
-      ) : (
-        <>
-          {error && <p className="app__status app__status--error">{error}</p>}
-          <ul>
-            {movies.map((movie) => (
-              <li key={movie.id}>{movie.title}</li>
-            ))}
-          </ul>
-        </>
+      {moviesError && (
+        <StatusMessage tone="error" role="alert">
+          {moviesError}
+        </StatusMessage>
       )}
+
+      <div className="app__content">
+        <section className="app__grid-panel">
+          <div className="app__section-header">
+            <h2 className="app__section-title">Tilgjengelige titler</h2>
+            <p className="app__section-description">
+              Velg en film for å se detaljer, varighet og API-informasjon.
+            </p>
+          </div>
+
+          <MovieGrid
+            movies={movies}
+            isLoading={isLoadingMovies}
+            activeMovie={activeMovie}
+            onSelectMovie={setActiveMovie}
+          />
+        </section>
+
+        <DetailsPanel
+          movie={activeDetails}
+          isLoading={isLoadingDetails}
+          error={detailsError}
+          playbackHref={playbackHref}
+        />
+      </div>
     </div>
   )
 }
 
 export default App
+
+function buildPlaybackHref(path?: string | null): string | null {
+  if (!path) {
+    return null
+  }
+
+  const cleanPath = path.replace(/^\/+/, '')
+  if (!cleanPath) {
+    return null
+  }
+
+  return `https://ai.play.tv2.no/${cleanPath}`
+}


### PR DESCRIPTION
## Summary
- replace the simple list view with a full grid/detail layout styled to mirror TV 2 Play
- fetch and display movie details on selection, including error handling and playback link generation
- refresh global styling with gradients, panels, and responsive layout to highlight the catalog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea1939b18832f97ec429c82f51c7d