### PR TITLE
Redesign landing page to reflect TV 2 Play style

### DIFF
--- a/tv2/src/App.css
+++ b/tv2/src/App.css
@@ -1,317 +1,563 @@
 #root {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: clamp(1.5rem, 4vw, 3rem);
+  min-height: 100vh;
 }
 
 .app {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.app__content {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-  grid-template-columns: minmax(0, 1.8fr) minmax(0, 2fr);
-  align-items: flex-start;
-}
-
-.app__title-accent {
-  font-weight: 600;
-  color: #5cb6ff;
-}
-
-.app__grid-panel {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1rem, 3vw, 1.5rem);
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border-radius: 1.25rem;
-  background: linear-gradient(150deg, rgba(8, 12, 24, 0.88), rgba(5, 7, 15, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 22px 45px rgba(5, 8, 16, 0.55);
-}
-
-.app__section-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.app__section-title {
-  margin: 0;
-  font-size: clamp(1.2rem, 3vw, 1.6rem);
-  font-weight: 600;
-}
-
-.app__section-description {
-  margin: 0;
-  color: rgba(246, 247, 251, 0.7);
-  font-size: 0.95rem;
-}
-
-.app__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  background: radial-gradient(circle at top left, rgba(23, 24, 48, 0.8), rgba(5, 7, 15, 0.98) 55%),
+    radial-gradient(circle at bottom right, rgba(98, 62, 156, 0.45), rgba(5, 7, 15, 0.98) 60%);
   color: #f6f7fb;
-}
-
-.app__title {
-  margin: 0;
-  font-size: clamp(2.25rem, 5vw, 3rem);
-  font-weight: 700;
-}
-
-.app__subtitle {
-  margin: 0;
-  max-width: 65ch;
-  color: rgba(246, 247, 251, 0.75);
-  font-size: 1.05rem;
-}
-
-.app__status {
-  padding: 0.85rem 1.1rem;
-  border-radius: 0.9rem;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: #f6f7fb;
-}
-
-.app__status--error {
-  background: rgba(255, 76, 76, 0.15);
-  border-color: rgba(255, 112, 112, 0.4);
-  color: #ffd6d9;
-}
-
-.movie-grid {
-  display: grid;
-  gap: clamp(1rem, 3vw, 1.5rem);
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.movie-card {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(160deg, rgba(27, 37, 63, 0.8), rgba(12, 15, 28, 0.92));
-  color: inherit;
-  padding: 0;
-  overflow: hidden;
-  text-align: left;
-  min-height: 100%;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-button.movie-card {
-  cursor: pointer;
+.shell {
+  width: min(1180px, 100% - 2.5rem);
+  margin: 0 auto;
 }
 
-button.movie-card:focus {
-  outline: none;
+.top-nav {
+  background: rgba(12, 10, 26, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(16px);
 }
 
-button.movie-card:focus-visible {
-  outline: 3px solid #8cc7ff;
-  outline-offset: 2px;
-}
-
-button.movie-card:hover,
-button.movie-card:active {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 35px rgba(5, 8, 16, 0.55);
-  border-color: rgba(255, 255, 255, 0.18);
-}
-
-.movie-card--active {
-  box-shadow: 0 20px 40px rgba(5, 8, 16, 0.6);
-  border-color: rgba(140, 199, 255, 0.6);
-  transform: translateY(-4px);
-}
-
-.movie-card__poster {
-  width: 100%;
-  aspect-ratio: 2 / 3;
-  object-fit: cover;
-  background: rgba(12, 14, 24, 0.7);
-}
-
-.movie-card__poster--empty {
+.top-nav__inner {
   display: flex;
   align-items: center;
-  justify-content: center;
-  color: rgba(246, 247, 251, 0.6);
-  font-weight: 600;
-  font-size: 0.95rem;
-  letter-spacing: 0.02em;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.1rem 0;
 }
 
-.movie-card__poster--skeleton {
-  position: relative;
-  background: linear-gradient(135deg, rgba(40, 52, 90, 0.6), rgba(22, 27, 43, 0.6));
-  overflow: hidden;
-}
-
-.movie-card__poster--skeleton::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, transparent 20%, rgba(255, 255, 255, 0.2) 50%, transparent 80%);
-  animation: shimmer 1.4s infinite;
-}
-
-.movie-card__title {
-  margin: 0;
-  padding: 0.85rem 1rem 1.1rem;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: #f6f7fb;
-}
-
-.movie-card__title--skeleton {
-  height: 1.1rem;
-  margin: 0.75rem 1rem 1.2rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
-  animation: pulse 1.5s infinite;
-}
-
-.movie-card--loading {
-  pointer-events: none;
-}
-
-.details {
-  position: relative;
+.top-nav__brand {
   display: flex;
-  flex-wrap: wrap;
-  gap: clamp(1.25rem, 3vw, 2.5rem);
-  align-items: flex-start;
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  border-radius: 1.25rem;
-  background: linear-gradient(140deg, rgba(16, 19, 35, 0.95), rgba(9, 11, 20, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #f6f7fb;
+  align-items: center;
+  gap: 0.65rem;
 }
 
-.details__skeleton {
-  width: 100%;
-  min-height: 280px;
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.08);
-  animation: pulse 1.5s infinite;
-}
-
-.details__poster {
-  width: min(280px, 40vw);
-  max-width: 100%;
-  border-radius: 1rem;
-  object-fit: cover;
-  aspect-ratio: 2 / 3;
-  box-shadow: 0 24px 48px rgba(5, 8, 16, 0.65);
-}
-
-.details__body {
-  flex: 1 1 260px;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.details__title {
-  margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  font-weight: 700;
-}
-
-.details__description {
-  margin: 0;
-  line-height: 1.7;
-  color: rgba(246, 247, 251, 0.8);
-}
-
-.details__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem 1.5rem;
-  color: rgba(246, 247, 251, 0.72);
-  font-weight: 500;
-}
-
-.details__actions {
-  display: flex;
-}
-
-.details__link {
+.top-nav__logo {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 1.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #7427ff, #c164ff);
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.top-nav__links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.top-nav__link {
+  color: rgba(246, 247, 251, 0.75);
+  text-decoration: none;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.top-nav__link:hover,
+.top-nav__link:focus {
+  color: #ffffff;
+}
+
+.top-nav__link::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -0.45rem;
+  height: 2px;
+  background: linear-gradient(135deg, #7427ff, #c164ff);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.2s ease;
+}
+
+.top-nav__link:hover::after,
+.top-nav__link:focus::after {
+  transform: scaleX(1);
+}
+
+.top-nav__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.top-nav__action {
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  background: linear-gradient(120deg, #0d8bff, #5a4bff);
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, #7427ff, #c164ff);
   color: #fff;
-  text-decoration: none;
+  border: none;
+  cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.details__link:hover,
-.details__link:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 26px rgba(13, 139, 255, 0.35);
+.top-nav__action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(108, 60, 204, 0.35);
 }
 
-.details__empty {
-  width: 100%;
-  text-align: center;
+.top-nav__action--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f6f7fb;
+  box-shadow: none;
+}
+
+.top-nav__action--ghost:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.app__main {
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  padding: 3rem 0 4rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.hero__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 560px;
+}
+
+.hero__eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 190, 255, 0.85);
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  line-height: 1.05;
+}
+
+.hero__subtitle {
+  margin: 0;
   color: rgba(246, 247, 251, 0.75);
+  font-size: 1.05rem;
 }
 
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
+.hero__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 1.5rem;
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
-  50% {
-    opacity: 1;
-  }
+.hero-card {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  min-height: 280px;
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 25px 50px rgba(8, 11, 24, 0.45);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
-@media (max-width: 1024px) {
-  .app__content {
-    grid-template-columns: 1fr;
+.hero-card--primary {
+  grid-row: span 2;
+  min-height: 420px;
+}
+
+.hero-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 60px rgba(8, 11, 24, 0.55);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.hero-card__content {
+  position: relative;
+  padding: 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 1;
+  max-width: 360px;
+}
+
+.hero-card__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.hero-card__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.3rem);
+  line-height: 1.1;
+}
+
+.hero-card__description {
+  margin: 0;
+  color: rgba(246, 247, 251, 0.78);
+  font-size: 1rem;
+}
+
+.hero-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.button {
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #7427ff, #c164ff);
+  color: #fff;
+  box-shadow: 0 10px 24px rgba(108, 60, 204, 0.3);
+}
+
+.button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(108, 60, 204, 0.4);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.chip--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(246, 247, 251, 0.85);
+}
+
+.chip--pill {
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+}
+
+.section__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(246, 247, 251, 0.7);
+}
+
+.section__cta {
+  align-self: center;
+  padding: 0.5rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.section__cta:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.channel-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+}
+
+.channel-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.4rem;
+  min-height: 180px;
+  border-radius: 1.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 18px 40px rgba(8, 11, 24, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.channel-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 50px rgba(8, 11, 24, 0.45);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.channel-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.channel-card__meta {
+  margin: 0;
+  color: rgba(246, 247, 251, 0.75);
+  font-size: 0.9rem;
+}
+
+.sport-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.sport-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 1.4rem;
+  min-height: 220px;
+  background-size: cover;
+  background-position: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 45px rgba(8, 11, 24, 0.4);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.sport-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 28px 55px rgba(8, 11, 24, 0.5);
+}
+
+.sport-card__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(246, 247, 251, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sport-card__title {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.sport-card__meta {
+  margin: 0;
+  color: rgba(246, 247, 251, 0.75);
+  font-size: 0.95rem;
+}
+
+.popular-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.popular-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 260px;
+  border-radius: 1.4rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 22px 48px rgba(8, 11, 24, 0.42);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.popular-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 30px 58px rgba(8, 11, 24, 0.52);
+}
+
+.popular-card__rank {
+  position: absolute;
+  top: 1.2rem;
+  left: 1.2rem;
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.popular-card__content {
+  position: relative;
+  padding: 2rem 1.5rem 1.7rem;
+  background: linear-gradient(180deg, transparent 0%, rgba(6, 9, 20, 0.85) 65%, rgba(6, 9, 20, 0.95) 100%);
+}
+
+.popular-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.popular-card__meta {
+  margin: 0.35rem 0 0;
+  color: rgba(246, 247, 251, 0.7);
+  font-size: 0.9rem;
+}
+
+.footer {
+  margin-top: auto;
+  padding: 2rem 0 3rem;
+}
+
+.footer__text {
+  margin: 0;
+  text-align: center;
+  color: rgba(246, 247, 251, 0.55);
+  font-size: 0.85rem;
+}
+
+.app__status {
+  width: min(1180px, 100% - 2.5rem);
+  margin: 0 auto;
+  padding: 1rem 1.4rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #f6f7fb;
+  font-weight: 500;
+}
+
+.app__status--error {
+  background: rgba(255, 92, 92, 0.18);
+  border-color: rgba(255, 132, 132, 0.4);
+  color: #ffe5e6;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.75rem;
+  background: rgba(12, 10, 26, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.9rem;
+  color: rgba(246, 247, 251, 0.85);
+  box-shadow: 0 16px 32px rgba(8, 11, 24, 0.45);
+}
+
+@media (max-width: 1080px) {
+  .top-nav__inner {
+    flex-wrap: wrap;
+  }
+
+  .top-nav__links {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    row-gap: 0.6rem;
+  }
+
+  .hero__grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .hero-card--primary {
+    grid-row: auto;
   }
 }
 
 @media (max-width: 768px) {
-  .movie-grid {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  .top-nav__links {
+    display: none;
   }
 
-  .details {
-    padding: clamp(1.1rem, 6vw, 1.8rem);
+  .shell {
+    width: min(100%, 100% - 1.8rem);
   }
 
-  .details__poster {
-    width: 100%;
+  .app__main {
+    padding: 2.5rem 0 3rem;
+    gap: 3rem;
+  }
+
+  .hero__title {
+    font-size: clamp(2.1rem, 8vw, 2.6rem);
+  }
+
+  .hero-card__content {
+    padding: 2rem;
+  }
+
+  .section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section__cta {
+    align-self: flex-start;
+  }
+
+  .channel-row,
+  .sport-grid,
+  .popular-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }
 
-@media (min-width: 769px) {
-  .app__content {
-    grid-template-columns: minmax(0, 1.7fr) minmax(0, 2.3fr);
+@media (max-width: 520px) {
+  .hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    min-height: 240px;
+  }
+
+  .sport-card {
+    min-height: 180px;
   }
 }

--- a/tv2/src/App.tsx
+++ b/tv2/src/App.tsx
@@ -1,83 +1,281 @@
 import { useEffect, useMemo, useState } from 'react'
 import './App.css'
-import { fetchMovieDetails, fetchMovies } from './api/movies'
-import type { MovieDetails, MovieSummary } from './api/movies'
-import { isAbortError } from './utils/errors'
-import AppHeader from './components/AppHeader'
-import MovieGrid from './components/MovieGrid'
-import DetailsPanel from './components/DetailsPanel'
+import { fetchMovies } from './api/movies'
+import type { MovieSummary } from './api/movies'
 import StatusMessage from './components/StatusMessage'
+import { isAbortError } from './utils/errors'
+
+type HeroShow = {
+  tag: string
+  category: string
+  title: string
+  description: string
+  ctaLabel: string
+  imageUrl: string
+}
+
+type ChannelCard = {
+  id: string
+  label: string
+  description: string
+  imageUrl: string
+}
+
+type SportEvent = {
+  id: string
+  label: string
+  matchup: string
+  time: string
+  imageUrl: string
+}
+
+type SeriesHighlight = {
+  id: string
+  rank: number
+  title: string
+  description: string
+  imageUrl: string
+}
 
 const FALLBACK_MOVIES: MovieSummary[] = [
   {
-    id: 'sample-nordlysjakten',
-    title: 'Nordlysjakten',
-    url: 'sample/nordlysjakten',
+    id: 'sample-norges-dummeste',
+    title: 'Norges Dummeste',
+    url: 'sample/norges-dummeste',
     imageUrl:
-      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=80',
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80',
   },
   {
-    id: 'sample-sommerbris',
-    title: 'Sommerbris',
-    url: 'sample/sommerbris',
+    id: 'sample-jakten-pa-kjarligheten',
+    title: 'Jakten på kjærligheten',
+    url: 'sample/jakten-pa-kjarligheten',
     imageUrl:
-      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=600&q=80',
+      'https://images.unsplash.com/photo-1495063370686-23d761589a87?auto=format&fit=crop&w=1400&q=80',
   },
   {
-    id: 'sample-midnattsløp',
-    title: 'Midnattsløpet',
-    url: 'sample/midnattslopet',
+    id: 'sample-moc-xyferitime',
+    title: 'Mørk dyreflimmer',
+    url: 'sample/mork-dyreflimmer',
     imageUrl:
-      'https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=600&q=80',
+      'https://images.unsplash.com/photo-1468070454955-c5b6932bd08d?auto=format&fit=crop&w=1400&q=80',
+  },
+  {
+    id: 'sample-rosenborg',
+    title: 'Rosenborg – Røa',
+    url: 'sample/rosenborg-roa',
+    imageUrl:
+      'https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?auto=format&fit=crop&w=1400&q=80',
+  },
+  {
+    id: 'sample-narvik',
+    title: 'Narvik – Sparta',
+    url: 'sample/narvik-sparta',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1400&q=80',
+  },
+  {
+    id: 'sample-bloggerne',
+    title: 'Bloggerne',
+    url: 'sample/bloggerne',
+    imageUrl:
+      'https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=1400&q=80',
   },
 ]
 
+const HERO_DEFAULTS: HeroShow[] = [
+  {
+    tag: 'Ny episode',
+    category: 'Reality',
+    title: 'Norges Dummeste',
+    description: 'Latterlig eksperiment og det beste fra ukens klipp.',
+    ctaLabel: 'Se nå',
+    imageUrl:
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80',
+  },
+  {
+    tag: 'Ny episode',
+    category: 'Romantikk',
+    title: 'Jakten på kjærligheten',
+    description: 'Speed-datingen fortsetter og bøndene finner sine matcher.',
+    ctaLabel: 'Se nå',
+    imageUrl:
+      'https://images.unsplash.com/photo-1495063370686-23d761589a87?auto=format&fit=crop&w=1400&q=80',
+  },
+  {
+    tag: 'Film',
+    category: 'Thriller',
+    title: 'Mørk dyreflimmer',
+    description: 'Mystikk, spenning og uventede hendelser i skogen.',
+    ctaLabel: 'Spill av',
+    imageUrl:
+      'https://images.unsplash.com/photo-1468070454955-c5b6932bd08d?auto=format&fit=crop&w=1400&q=80',
+  },
+]
+
+const CHANNELS: ChannelCard[] = [
+  {
+    id: 'direct',
+    label: 'Direkte',
+    description: 'Nå: Nyhetsoppdatering',
+    imageUrl:
+      'https://images.unsplash.com/photo-1511690656952-34342bb7c2f2?auto=format&fit=crop&w=800&q=80',
+  },
+  {
+    id: 'nyheter',
+    label: 'Nyheter',
+    description: 'Nå: Toppnyhetene',
+    imageUrl:
+      'https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=800&q=80',
+  },
+  {
+    id: 'sport',
+    label: 'Sport 1',
+    description: 'Nå: Toppserien kvinner',
+    imageUrl:
+      'https://images.unsplash.com/photo-1508098682722-e99c43a406b2?auto=format&fit=crop&w=800&q=80',
+  },
+  {
+    id: 'obos',
+    label: 'OBOS-ligaen',
+    description: 'Snart: Kvalifiseringsrunde',
+    imageUrl:
+      'https://images.unsplash.com/photo-1444492696363-332accfd55ec?auto=format&fit=crop&w=800&q=80',
+  },
+  {
+    id: 'sport2',
+    label: 'Sport 2',
+    description: 'Nå: NHL Direktesending',
+    imageUrl:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80',
+  },
+  {
+    id: 'zebra',
+    label: 'Zebra',
+    description: 'Nå: Cops',
+    imageUrl:
+      'https://images.unsplash.com/photo-1549923746-c502d488b3ea?auto=format&fit=crop&w=800&q=80',
+  },
+]
+
+const SPORT_EVENTS_BASE: SportEvent[] = [
+  {
+    id: 'rbk-rea',
+    label: 'I dag 18:00',
+    matchup: 'Rosenborg – Røa',
+    time: 'Fotball · Kvinner',
+    imageUrl:
+      'https://images.unsplash.com/photo-1521417531270-9b6821052d7f?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'ful-runde',
+    label: 'I dag 19:55',
+    matchup: 'Full runde',
+    time: 'Håndball · Eliteserien',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'rbk-rex',
+    label: 'I dag 20:00',
+    matchup: 'Rosenborg – Rea',
+    time: 'Fotball · Kvinner',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'stavanger',
+    label: 'I dag 20:10',
+    matchup: 'Stavanger Oilers – Vålerenga',
+    time: 'Ishockey · Fjordkraft-ligaen',
+    imageUrl:
+      'https://images.unsplash.com/photo-1513171920216-2640b288471b?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'narvik',
+    label: 'I dag 19:15',
+    matchup: 'Narvik – Sparta',
+    time: 'Ishockey · Fjordkraft-ligaen',
+    imageUrl:
+      'https://images.unsplash.com/photo-1511688878353-3a2f5be94cd7?auto=format&fit=crop&w=1200&q=80',
+  },
+]
+
+const POPULAR_SERIES_BASE: SeriesHighlight[] = [
+  {
+    id: 'rank-1',
+    rank: 1,
+    title: 'Norges Dummeste',
+    description: '10 på topp nå',
+    imageUrl:
+      'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'rank-2',
+    rank: 2,
+    title: 'Jakten på kjærligheten',
+    description: 'Romantikk',
+    imageUrl:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'rank-3',
+    rank: 3,
+    title: 'Spillet',
+    description: 'Drama',
+    imageUrl:
+      'https://images.unsplash.com/photo-1515169067865-5387ec356754?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'rank-4',
+    rank: 4,
+    title: 'Dommeste',
+    description: 'Humor',
+    imageUrl:
+      'https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    id: 'rank-5',
+    rank: 5,
+    title: 'Bloggerne',
+    description: 'Reality',
+    imageUrl:
+      'https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=1200&q=80',
+  },
+]
+
+const NAV_LINKS = ['Play', 'Sport', 'Film', 'Serier', 'Nyheter', 'Kanaler', 'Barn']
+
 function App() {
   const [movies, setMovies] = useState<MovieSummary[]>([])
-  const [activeMovie, setActiveMovie] = useState<MovieSummary | null>(null)
-  const [isLoadingMovies, setIsLoadingMovies] = useState(true)
-  const [moviesError, setMoviesError] = useState<string | null>(null)
-  const [activeDetails, setActiveDetails] = useState<MovieDetails | null>(null)
-  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
-  const [detailsError, setDetailsError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const controller = new AbortController()
-    setIsLoadingMovies(true)
-    setMoviesError(null)
+    setIsLoading(true)
+    setError(null)
 
     fetchMovies(controller.signal)
       .then((fetched) => {
         if (fetched.length === 0) {
           setMovies(FALLBACK_MOVIES)
-          setMoviesError('Fant ingen filmer i feeden. Viser eksempeldata i stedet.')
-          setActiveMovie(FALLBACK_MOVIES[0] ?? null)
+          setError('Fant ingen titler i feeden. Viser eksempelinnhold.')
           return
         }
 
         setMovies(fetched)
-        setActiveMovie((current) => {
-          if (!current) {
-            return fetched[0] ?? null
-          }
-
-          return (
-            fetched.find((movie) => movie.id === current.id || movie.url === current.url) ?? fetched[0] ?? null
-          )
-        })
       })
-      .catch((error) => {
-        if (isAbortError(error)) {
+      .catch((fetchError) => {
+        if (isAbortError(fetchError)) {
           return
         }
 
-        console.error('Kunne ikke hente filmer fra API-et', error)
+        console.error('Kunne ikke hente titler', fetchError)
         setMovies(FALLBACK_MOVIES)
-        setMoviesError('Kunne ikke hente filmer fra API-et. Viser eksempeldata i stedet.')
-        setActiveMovie(FALLBACK_MOVIES[0] ?? null)
+        setError('Kunne ikke hente titler fra API-et. Viser eksempelinnhold i stedet.')
       })
       .finally(() => {
-        setIsLoadingMovies(false)
+        setIsLoading(false)
       })
 
     return () => {
@@ -85,101 +283,206 @@ function App() {
     }
   }, [])
 
-  useEffect(() => {
-    if (!activeMovie) {
-      setActiveDetails(null)
-      setDetailsError(null)
-      return
-    }
+  const heroShows = useMemo(() => {
+    const lineup = [...movies, ...FALLBACK_MOVIES]
 
-    const controller = new AbortController()
-    setIsLoadingDetails(true)
-    setDetailsError(null)
-    setActiveDetails(null)
+    return HERO_DEFAULTS.map((show, index) => {
+      const movie = lineup[index]
+      return {
+        ...show,
+        title: movie?.title ?? show.title,
+        imageUrl: movie?.imageUrl ?? show.imageUrl,
+      }
+    })
+  }, [movies])
 
-    fetchMovieDetails(activeMovie.url, controller.signal, activeMovie)
-      .then((details) => {
-        setActiveDetails(details)
-      })
-      .catch((error) => {
-        if (isAbortError(error)) {
-          return
-        }
+  const sportEvents = useMemo(() => {
+    const lineup = [...movies.slice(3), ...FALLBACK_MOVIES]
 
-        console.error('Kunne ikke hente detaljer for filmen', error)
-        setDetailsError('Kunne ikke hente detaljer for denne filmen akkurat nå. Viser begrenset info i stedet.')
-        setActiveDetails({
-          ...activeMovie,
-          description: 'Vi kunne ikke hente mer informasjon om denne filmen akkurat nå.',
-        })
-      })
-      .finally(() => {
-        setIsLoadingDetails(false)
-      })
+    return SPORT_EVENTS_BASE.map((event, index) => {
+      const movie = lineup[index]
+      return {
+        ...event,
+        imageUrl: movie?.imageUrl ?? event.imageUrl,
+      }
+    })
+  }, [movies])
 
-    return () => {
-      controller.abort()
-    }
-  }, [activeMovie])
+  const popularSeries = useMemo(() => {
+    const lineup = [...movies.slice(1), ...FALLBACK_MOVIES]
 
-  const playbackHref = useMemo(() => buildPlaybackHref(activeDetails?.url), [activeDetails?.url])
+    return POPULAR_SERIES_BASE.map((series, index) => {
+      const movie = lineup[index]
+      return {
+        ...series,
+        title: movie?.title ?? series.title,
+        imageUrl: movie?.imageUrl ?? series.imageUrl,
+      }
+    })
+  }, [movies])
 
   return (
     <div className="app">
-      <AppHeader
-        title={
-          <>
-            TV 2 Play <span className="app__title-accent">demo</span>
-          </>
-        }
-        subtitle="Utforsk filmlisten som hentes direkte fra TV 2 Play sitt API og se detaljer i sanntid."
-      />
-
-      {moviesError && (
-        <StatusMessage tone="error" role="alert">
-          {moviesError}
-        </StatusMessage>
-      )}
-
-      <div className="app__content">
-        <section className="app__grid-panel">
-          <div className="app__section-header">
-            <h2 className="app__section-title">Tilgjengelige titler</h2>
-            <p className="app__section-description">
-              Velg en film for å se detaljer, varighet og API-informasjon.
-            </p>
+      <div className="top-nav">
+        <div className="top-nav__inner shell">
+          <div className="top-nav__brand">
+            <span className="top-nav__logo">TV 2 Play</span>
           </div>
 
-          <MovieGrid
-            movies={movies}
-            isLoading={isLoadingMovies}
-            activeMovie={activeMovie}
-            onSelectMovie={setActiveMovie}
-          />
+          <nav aria-label="Hovedmeny" className="top-nav__links">
+            {NAV_LINKS.map((link) => (
+              <a key={link} href="#" className="top-nav__link">
+                {link}
+              </a>
+            ))}
+          </nav>
+
+          <div className="top-nav__actions">
+            <button type="button" className="top-nav__action top-nav__action--ghost">
+              Logg inn
+            </button>
+            <button type="button" className="top-nav__action">
+              Få tilgang
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <main className="app__main">
+        <section className="hero shell">
+          <header className="hero__header">
+            <span className="hero__eyebrow">Ny episode</span>
+            <h1 className="hero__title">Alt dette kan du se med TV 2 Play</h1>
+            <p className="hero__subtitle">Opplev det beste fra live-kanaler, sport og våre mest populære serier.</p>
+          </header>
+
+          <div className="hero__grid">
+            {heroShows.map((show, index) => (
+              <article
+                key={show.title}
+                className={`hero-card${index === 0 ? ' hero-card--primary' : ''}`}
+                style={{
+                  backgroundImage: `linear-gradient(120deg, rgba(8, 11, 25, 0.92) 10%, rgba(8, 11, 25, 0.5) 55%, rgba(8, 11, 25, 0.2) 100%), url(${show.imageUrl})`,
+                }}
+              >
+                <div className="hero-card__content">
+                  <div className="hero-card__meta">
+                    <span className="chip">{show.tag}</span>
+                    <span className="chip chip--ghost">{show.category}</span>
+                  </div>
+                  <h2 className="hero-card__title">{show.title}</h2>
+                  <p className="hero-card__description">{show.description}</p>
+                  <div className="hero-card__actions">
+                    <button type="button" className="button button--primary">
+                      {show.ctaLabel}
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
         </section>
 
-        <DetailsPanel
-          movie={activeDetails}
-          isLoading={isLoadingDetails}
-          error={detailsError}
-          playbackHref={playbackHref}
-        />
-      </div>
+        {error && (
+          <StatusMessage tone="error" role="alert">
+            {error}
+          </StatusMessage>
+        )}
+
+        <section className="section shell">
+          <header className="section__header">
+            <div>
+              <h2 className="section__title">Se TV 2s kanaler direkte</h2>
+              <p className="section__subtitle">Direktesendt innhold, akkurat nå.</p>
+            </div>
+            <button type="button" className="section__cta">
+              Se alle
+            </button>
+          </header>
+
+          <div className="channel-row">
+            {CHANNELS.map((channel) => (
+              <article
+                key={channel.id}
+                className="channel-card"
+                style={{
+                  backgroundImage: `linear-gradient(160deg, rgba(12, 13, 26, 0.95) 10%, rgba(12, 13, 26, 0.75) 60%, rgba(12, 13, 26, 0.5) 100%), url(${channel.imageUrl})`,
+                }}
+              >
+                <span className="chip chip--pill">{channel.label}</span>
+                <h3 className="channel-card__title">{channel.description}</h3>
+                <p className="channel-card__meta">Direkte</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section shell">
+          <header className="section__header">
+            <div>
+              <h2 className="section__title">Direktesendt sport</h2>
+              <p className="section__subtitle">Hold deg oppdatert på ukens kamper og høydepunkter.</p>
+            </div>
+            <button type="button" className="section__cta">
+              Se alle
+            </button>
+          </header>
+
+          <div className="sport-grid">
+            {sportEvents.map((event) => (
+              <article
+                key={event.id}
+                className="sport-card"
+                style={{
+                  backgroundImage: `linear-gradient(150deg, rgba(10, 12, 24, 0.9) 20%, rgba(10, 12, 24, 0.65) 70%), url(${event.imageUrl})`,
+                }}
+              >
+                <span className="sport-card__label">{event.label}</span>
+                <h3 className="sport-card__title">{event.matchup}</h3>
+                <p className="sport-card__meta">{event.time}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section shell">
+          <header className="section__header">
+            <div>
+              <h2 className="section__title">Våre mest populære serier</h2>
+              <p className="section__subtitle">Se hva som trender på TV 2 Play akkurat nå.</p>
+            </div>
+          </header>
+
+          <div className="popular-grid">
+            {popularSeries.map((series) => (
+              <article
+                key={series.id}
+                className="popular-card"
+                style={{
+                  backgroundImage: `linear-gradient(160deg, rgba(8, 10, 20, 0.95) 10%, rgba(8, 10, 20, 0.7) 65%), url(${series.imageUrl})`,
+                }}
+              >
+                <span className="popular-card__rank">{series.rank}</span>
+                <div className="popular-card__content">
+                  <h3 className="popular-card__title">{series.title}</h3>
+                  <p className="popular-card__meta">{series.description}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="footer shell">
+        <p className="footer__text">
+          © {new Date().getFullYear()} TV 2 Play · All rights reserved. Innholdet er et demodesign inspirert av TV 2
+          Play.
+        </p>
+      </footer>
+
+      {isLoading && <div className="loading-overlay">Laster innhold …</div>}
     </div>
   )
 }
 
 export default App
-
-function buildPlaybackHref(path?: string | null): string | null {
-  if (!path) {
-    return null
-  }
-
-  const cleanPath = path.replace(/^\/+/, '')
-  if (!cleanPath) {
-    return null
-  }
-
-  return `https://ai.play.tv2.no/${cleanPath}`
-}


### PR DESCRIPTION
## Summary
- rework the app layout into a TV 2 Play-inspired landing page with hero, channel, sport, and popular series sections
- add curated fallback data and responsive styling to keep the experience rich even when the API feed is empty

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea3415c94832f9b19325d54ba056d